### PR TITLE
Feature/ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ulimit -n 1024; fi
 
 install:
-  - dotnet restore BreezeServer.sln
+  - dotnet restore BreezeClient.sln
 script:
   - echo "Let's write some tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_install:
 install:
   - dotnet restore BreezeClient.sln
 script:
-  - echo "Let's write some tests"
+  - echo "Let's write some tests next"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
 
 branches:
   only:
-  - feature/ci
   - master
 
 # Work around NuGet issue #2163

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: csharp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      dotnet: 1.0.4
+      mono: none
+    - os: osx
+      osx_image: xcode7.3
+      dotnet: 1.0.4
+      mono: none
+
+branches:
+  only:
+  - feature/ci
+  - master
+
+# Work around NuGet issue #2163
+# Too many files open error
+# https://github.com/NuGet/Home/issues/2163
+# https://github.com/travis-ci/travis-ci/issues/7728
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ulimit -n 1024; fi
+
+install:
+  - dotnet restore BreezeServer.sln
+script:
+  - echo "Let's write some tests"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
+| Windows | Linux | OS X |
+| :---- | :---- | :---- |
+[![Windows build status][1]][2] | [![Linux build status][3]][4] | [![OS X build status][5]][6] |
+
+[1]: https://ci.appveyor.com/api/projects/status/h3dl5gd1bvkk1vvt?svg=true
+[2]: https://ci.appveyor.com/api/projects/status/h3dl5gd1bvkk1vvt/branch/master
+[3]: https://travis-ci.org/BreezeHub/BreezeClient.svg?branch=master
+[4]: https://travis-ci.org/BreezeHub/BreezeClient
+[5]: https://travis-ci.org/BreezeHub/BreezeClient.svg?branch=master
+[6]: https://travis-ci.org/BreezeHub/BreezeClient
+
+
 # BreezeClient
 Breeze Wallet plugin for the Breeze Privacy Protocol (based on NTumbleBit).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+version: '1.0.{build}'
+image: Visual Studio 2017
+branches:
+  only:
+  - feature/ci
+  - master
+
+# see http://status.appveyor.com/ re:connectivity issues for nuget
+hosts:
+ api.nuget.org: 93.184.221.200
+
+init:
+  # Good practise, because Windows
+  - cmd: git config --global core.autocrlf true
+install:
+  # need to do the recursice clone here for submodules
+  git submodule update --init --recursive
+before_build:
+  # Display .NET Core version
+  - cmd: dotnet --version
+  # 
+  - cmd: dotnet restore ./BreezeClient.sln
+build_script:
+  #
+  - cmd: dotnet publish ./BreezeClient.sln
+after_build:
+  # For once the build has completed
+on_finish :
+  # any cleanup in here
+deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ branches:
   - feature/ci
   - master
 
+
 # see http://status.appveyor.com/ re:connectivity issues for nuget
 hosts:
  api.nuget.org: 93.184.221.200

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ version: '1.0.{build}'
 image: Visual Studio 2017
 branches:
   only:
-  - feature/ci
   - master
 
 # see http://status.appveyor.com/ re:connectivity issues for nuget

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ branches:
   - feature/ci
   - master
 
-
 # see http://status.appveyor.com/ re:connectivity issues for nuget
 hosts:
  api.nuget.org: 93.184.221.200


### PR DESCRIPTION
Sets up CI with Appveyor and Travis. Uses update StratisBitcoinFullNode to get recent the <TargetFramework> change

Appveyor project is linked to my github account rather than BreezeHubAdmin, so that needs to change and be reflected in the Build badges. Master shows failing on travis because I haven't pushed these changes to master. This branch succeeds to be built on linux/macos.