### PR TITLE
Removed any PaymentStateMachine logic originally imported from NTumbl…

### DIFF
--- a/Breeze.TumbleBit.Client/IStateMachine.cs
+++ b/Breeze.TumbleBit.Client/IStateMachine.cs
@@ -17,10 +17,5 @@
         /// Deletes the state of the current tumbling session..
         /// </summary>
         void Delete();
-
-        /// <summary>
-        /// Updates this the state of the current tumbling session.
-        /// </summary>
-        void Update();
     }
 }

--- a/Breeze.TumbleBit.Client/ITumblerService.cs
+++ b/Breeze.TumbleBit.Client/ITumblerService.cs
@@ -20,27 +20,5 @@ namespace Breeze.TumbleBit.Client
         /// </summary>
         /// <returns></returns>
         Task<ClassicTumblerParameters> GetClassicTumblerParametersAsync();
-
-        Task<UnsignedVoucherInformation> AskUnsignedVoucherAsync();
-
-        Task<PuzzleSolution> SignVoucherAsync(SignVoucherRequest signVoucherRequest);
-
-        Task<ScriptCoin> OpenChannelAsync(OpenChannelRequest request);
-
-        Task<TumblerEscrowKeyResponse> RequestTumblerEscrowKeyAsync(int cycleStart);
-
-        Task<ServerCommitmentsProof> CheckRevelationAsync(int cycleId, string channelId, PuzzlePromise.ClientRevelation revelation);
-
-        Task<SolutionKey[]> CheckRevelationAsync(int cycleId, string channelId, PuzzleSolver.ClientRevelation revelation);
-
-        Task<PuzzlePromise.ServerCommitment[]> SignHashesAsync(int cycleId, string channelId, SignaturesRequest sigReq);
-        
-        Task<OfferInformation> CheckBlindFactorsAsync(int cycleId, string channelId, BlindFactor[] blindFactors);
-
-        Task<PuzzleSolver.ServerCommitment[]> SolvePuzzlesAsync(int cycleId, string channelId, PuzzleValue[] puzzles);
-
-        Task<SolutionKey[]> FulfillOfferAsync(int cycleId, string channelId, TransactionSignature clientSignature);
-
-        Task GiveEscapeKeyAsync(int cycleId, string channelId, TransactionSignature signature);
     }
 }

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -43,6 +43,9 @@ namespace Breeze.TumbleBit.Client
         /// <inheritdoc />
         public async Task<ClassicTumblerParameters> ConnectToTumblerAsync(Uri serverAddress)
         {
+            // TODO this method will probably need to change as the connection to a tumbler is currently done during configuration
+            // of the TumblebitRuntime. This method can then be modified to potentially be a convenience method 
+            // where a user wants to check a tumbler's paramters before commiting to tumbling (and therefore before configuring the runtime).
             this.tumblerService = new TumblerService(serverAddress);
             this.TumblerParameters = await this.tumblerService.GetClassicTumblerParametersAsync();
 
@@ -57,7 +60,6 @@ namespace Breeze.TumbleBit.Client
             // update and save the state
             this.tumblingState.TumblerUri = serverAddress;
             this.tumblingState.TumblerParameters = this.TumblerParameters;
-            this.tumblingState.SetClients(this.tumblerService);
             this.tumblingState.Save();
 
             return this.TumblerParameters;

--- a/Breeze.TumbleBit.Client/TumbleBitManager.cs
+++ b/Breeze.TumbleBit.Client/TumbleBitManager.cs
@@ -130,8 +130,7 @@ namespace Breeze.TumbleBit.Client
             this.tumblingState.LastBlockReceivedHeight = height;
             this.tumblingState.Save();
             
-            // update the state of the tumbling session in this new block
-            this.tumblingState.Update();
+            // TODO update the state of the tumbling session in this new block
         }
     }
 }

--- a/Breeze.TumbleBit.Client/TumblerService.cs
+++ b/Breeze.TumbleBit.Client/TumblerService.cs
@@ -1,20 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Breeze.TumbleBit.Models;
 using Flurl;
 using Flurl.Http;
 using Flurl.Http.Configuration;
-using NBitcoin;
 using NBitcoin.JsonConverters;
 using Newtonsoft.Json;
-using NTumbleBit;
 using NTumbleBit.ClassicTumbler;
 using NTumbleBit.JsonConverters;
-using NTumbleBit.PuzzlePromise;
-using NTumbleBit.PuzzleSolver;
-using PuzzlePromise = NTumbleBit.PuzzlePromise;
-using PuzzleSolver = NTumbleBit.PuzzleSolver;
 
 namespace Breeze.TumbleBit.Client
 {
@@ -39,82 +32,6 @@ namespace Breeze.TumbleBit.Client
         {
             ClassicTumblerParameters result = await this.serverAddress.AppendPathSegment("/api/v1/tumblers/0/parameters").GetJsonAsync<ClassicTumblerParameters>();
             return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<UnsignedVoucherInformation> AskUnsignedVoucherAsync()
-        {
-            UnsignedVoucherInformation result = await this.serverAddress.AppendPathSegment("api/v1/tumblers/0/vouchers/").GetJsonAsync<UnsignedVoucherInformation>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<PuzzleSolution> SignVoucherAsync(SignVoucherRequest request)
-        {
-            PuzzleSolution result = await this.serverAddress.AppendPathSegment("api/v1/tumblers/0/clientchannels/confirm").PostJsonAsync(request).ReceiveJson<PuzzleSolution>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<ScriptCoin> OpenChannelAsync(OpenChannelRequest request)
-        {
-            ScriptCoin result = await this.serverAddress.AppendPathSegment("api/v1/tumblers/0/channels/").PostJsonAsync(request).ReceiveJson<ScriptCoin>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<TumblerEscrowKeyResponse> RequestTumblerEscrowKeyAsync(int cycleStart)
-        {
-            TumblerEscrowKeyResponse result = await this.serverAddress.AppendPathSegment("api/v1/tumblers/0/clientchannels/").PostJsonAsync(cycleStart).ReceiveJson<TumblerEscrowKeyResponse>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<ServerCommitmentsProof> CheckRevelationAsync(int cycleId, string channelId, PuzzlePromise.ClientRevelation revelation)
-        {
-            ServerCommitmentsProof result = await this.serverAddress.AppendPathSegment($"api/v1/tumblers/0/channels/{cycleId}/{channelId}/checkrevelation").PostJsonAsync(revelation).ReceiveJson<ServerCommitmentsProof>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<SolutionKey[]> CheckRevelationAsync(int cycleId, string channelId, PuzzleSolver.ClientRevelation revelation)
-        {
-            SolutionKey[] result = await this.serverAddress.AppendPathSegment($"api/v1/tumblers/0/clientschannels/{cycleId}/{channelId}/checkrevelation").PostJsonAsync(revelation).ReceiveJson<SolutionKey[]>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<PuzzlePromise.ServerCommitment[]> SignHashesAsync(int cycleId, string channelId, SignaturesRequest sigReq)
-        {
-            PuzzlePromise.ServerCommitment[] result = await this.serverAddress.AppendPathSegment($"api/v1/tumblers/0/channels/{cycleId}/{channelId}/signhashes").PostJsonAsync(sigReq).ReceiveJson<PuzzlePromise.ServerCommitment[]>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<OfferInformation> CheckBlindFactorsAsync(int cycleId, string channelId, BlindFactor[] blindFactors)
-        {
-            OfferInformation result = await this.serverAddress.AppendPathSegment($"api/v1/tumblers/0/clientschannels/{cycleId}/{channelId}/checkblindfactors").PostJsonAsync(blindFactors).ReceiveJson<OfferInformation>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<PuzzleSolver.ServerCommitment[]> SolvePuzzlesAsync(int cycleId, string channelId, PuzzleValue[] puzzles)
-        {
-            PuzzleSolver.ServerCommitment[] result = await this.serverAddress.AppendPathSegment($"api/v1/tumblers/0/clientchannels/{cycleId}/{channelId}/solvepuzzles").PostJsonAsync(puzzles).ReceiveJson<PuzzleSolver.ServerCommitment[]>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task<SolutionKey[]> FulfillOfferAsync(int cycleId, string channelId, TransactionSignature clientSignature)
-        {
-            SolutionKey[] result = await this.serverAddress.AppendPathSegment($"api/v1/tumblers/0/clientchannels/{cycleId}/{channelId}/offer").PostJsonAsync(clientSignature).ReceiveJson<SolutionKey[]>();
-            return result;
-        }
-
-        /// <inheritdoc />
-        public async Task GiveEscapeKeyAsync(int cycleId, string channelId, TransactionSignature signature)
-        {
-            await this.serverAddress.AppendPathSegment($"api/v1/tumblers/0/clientchannels/{cycleId}/{channelId}/escape").PostJsonAsync(signature);            
         }
     }
 }

--- a/Breeze.TumbleBit.Client/TumblingState.cs
+++ b/Breeze.TumbleBit.Client/TumblingState.cs
@@ -44,13 +44,7 @@ namespace Breeze.TumbleBit.Client
 
         [JsonIgnore]
         public Wallet DestinationWallet { get; set; }
-
-        [JsonIgnore]
-        public ITumblerService AliceClient { get; set; }
-
-        [JsonIgnore]
-        public ITumblerService BobClient { get; set; }
-
+        
         [JsonConstructor]
         public TumblingState()
         {
@@ -67,12 +61,6 @@ namespace Breeze.TumbleBit.Client
             this.walletManager = walletManager;
             this.watchOnlyWalletManager = watchOnlyWalletManager;
             this.coinType = (CoinType)network.Consensus.CoinType;
-        }
-
-        public void SetClients(ITumblerService tumblerService)
-        {
-            this.AliceClient = tumblerService;
-            this.BobClient = tumblerService;
         }
 
         /// <inheritdoc />

--- a/Breeze.TumbleBit.Client/TumblingState.cs
+++ b/Breeze.TumbleBit.Client/TumblingState.cs
@@ -14,7 +14,7 @@ using Stratis.Bitcoin.Features.WatchOnlyWallet;
 
 namespace Breeze.TumbleBit.Client
 {
-    public partial class TumblingState : IStateMachine
+    public class TumblingState : IStateMachine
     {
         private const string StateFileName = "tumblebit_state.json";
 
@@ -37,10 +37,7 @@ namespace Breeze.TumbleBit.Client
         public string OriginWalletName { get; set; }
 
         [JsonProperty("destinationWalletName", NullValueHandling = NullValueHandling.Ignore)]
-        public string DestinationWalletName { get; set; }
-
-        [JsonProperty("sessions", NullValueHandling = NullValueHandling.Ignore)]
-        public IList<Session> Sessions { get; set; }
+        public string DestinationWalletName { get; set; }       
 
         [JsonIgnore]
         public Wallet OriginWallet { get; set; }
@@ -95,8 +92,7 @@ namespace Breeze.TumbleBit.Client
 
             // load the file from the local system
             var savedState = JsonConvert.DeserializeObject<TumblingState>(File.ReadAllText(stateFilePath));
-
-            this.Sessions = savedState.Sessions ?? new List<Session>();
+            
             this.OriginWalletName = savedState.OriginWalletName;
             this.DestinationWalletName = savedState.DestinationWalletName;
             this.LastBlockReceivedHeight = savedState.LastBlockReceivedHeight;
@@ -110,75 +106,7 @@ namespace Breeze.TumbleBit.Client
             var stateFilePath = GetStateFilePath();
             File.Delete(stateFilePath);
         }
-
-        /// <inheritdoc />
-        public void Update()
-        {
-            // get the next cycle to be started
-            var cycle = this.TumblerParameters.CycleGenerator.GetRegistratingCycle(this.LastBlockReceivedHeight);
-
-            // create a new session if allowed
-            if (this.Sessions.Count == 0)
-            {
-                this.CreateNewSession(cycle.Start);
-            }
-            else
-            {
-                // TODO remove the limitation to have only 1 session
-                //var lastCycleStarted = this.Sessions.Max(s => s.StartCycle);
-
-                //// check if we need to start a new session starting from the registration cycle
-                //if (lastCycleStarted != cycle.Start)
-                //{
-                //    if (this.Sessions.SingleOrDefault(s => s.StartCycle == cycle.Start) == null)
-                //    {
-                //        this.CreateNewSession(cycle.Start);
-                //    }
-                //}
-            }
-
-            // get a list of cycles we expect to have at this height
-            var cycles = this.TumblerParameters.CycleGenerator.GetCycles(this.LastBlockReceivedHeight);
-            var existingSessions = cycles.SelectMany(c => this.Sessions.Where(s => s.StartCycle == c.Start)).ToList();
-            foreach (var existingSession in existingSessions)
-            {
-                // create a new session to be updated
-                var session = new Session();
-                if (existingSession.NegotiationClientState != null)
-                {
-                    session.StartCycle = existingSession.NegotiationClientState.CycleStart;
-                    session.ClientChannelNegotiation = new ClientChannelNegotiation(this.TumblerParameters, existingSession.NegotiationClientState);
-                }
-                if (existingSession.PromiseClientState != null)
-                    session.PromiseClientSession = new PromiseClientSession(this.TumblerParameters.CreatePromiseParamaters(), existingSession.PromiseClientState);
-                if (existingSession.SolverClientState != null)
-                    session.SolverClientSession = new SolverClientSession(this.TumblerParameters.CreateSolverParamaters(), existingSession.SolverClientState);
-
-                // update the session
-                this.MoveToNextPhase(session);
-
-                // replace the updated session in the list of existing sessions
-                int index = this.Sessions.IndexOf(existingSession);
-                if (index != -1)
-                {
-                    this.Sessions[index] = session;
-                }
-
-                this.Save();
-            }
-        }
-
-        public void MoveToNextPhase(Session session)
-        {
-            this.logger.LogInformation($"Entering next phase for cycle {session.StartCycle}.");
-        }
-
-        public void CreateNewSession(int start)
-        {
-            this.Sessions.Add(new Session { StartCycle = start });
-            this.Save();
-        }
-
+        
         /// <summary>
         /// Gets the file path of the file containing the state of the tumbling execution.
         /// </summary>
@@ -199,27 +127,5 @@ namespace Breeze.TumbleBit.Client
             Directory.CreateDirectory(defaultFolderPath);
             return Path.Combine(defaultFolderPath, StateFileName);
         }
-    }
-
-
-
-    public class Session
-    {
-        public int StartCycle { get; set; }
-
-        public ClientChannelNegotiation.State NegotiationClientState { get; set; }
-
-        public PromiseClientSession.State PromiseClientState { get; set; }
-
-        public SolverClientSession.State SolverClientState { get; set; }
-
-        [JsonIgnore]
-        public ClientChannelNegotiation ClientChannelNegotiation { get; set; }
-
-        [JsonIgnore]
-        public SolverClientSession SolverClientSession { get; set; }
-
-        [JsonIgnore]
-        public PromiseClientSession PromiseClientSession { get; set; }
     }
 }


### PR DESCRIPTION
* Removed any PaymentStateMachine logic originally imported from NTumbleBit. This will now be handled in tumbleBit exclusively.
https://trello.com/c/R2DnTmnE/29-1-remove-paymentstatemachine-from-breezeclient

* Removed any ITumblerService methods apart from the connectToTumbler one. Every request to the tumbler should be done from within the NTumbleBit Client so the BreezeTumbleBitCient doesn't need to worry about those.
The method to connect to a tumbler stayed as a convenience method to use when a user wants to check a tumbler's parameters before commiting to tumbling (and therefore before configuring the runtime).
https://trello.com/c/uS4QygeL/30-1-review-itumblerservice-methods-maybe-just-keep-the-getclassictumblerparametersasync-one