### PR TITLE
Reference the Api and LightWallet projects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "StratisBitcoinFullNode"]
 	path = StratisBitcoinFullNode
 	url = https://github.com/stratisproject/StratisBitcoinFullNode.git
+	branch = nstratis-as-nuget

--- a/Breeze.TumbleBit.Client.CLI/Breeze.TumbleBit.Client.CLI.csproj
+++ b/Breeze.TumbleBit.Client.CLI/Breeze.TumbleBit.Client.CLI.csproj
@@ -9,15 +9,4 @@
     <ProjectReference Include="..\Breeze.TumbleBit.Client\Breeze.TumbleBit.Client.csproj" />
   </ItemGroup>
 
-  <!-- The problem here is that when a project references both a nuget package and a csproj that lead to the same assembly, the compiler throws an exception.
-       The behavior that's expected is that the project reference wins.
-       Here, having NStratis in both the Stratis.Bitcoin project and in the NTumblebit project leads to an error. 
-       Workaround taken from here https://github.com/dotnet/sdk/issues/364 
-       TODO Remove this once we use nuget packages -->
-  <Target Name="WorkAroundPackageAndProjectReferenceConflict" BeforeTargets="ResolveLockFileReferences">
-    <ItemGroup>
-      <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'%(ResolvedCompileFileDefinitions.Filename)' == 'HashLib'" />
-      <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'%(ResolvedCompileFileDefinitions.Filename)' == 'NBitcoin'" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/Breeze.TumbleBit.Client.CLI/Breeze.TumbleBit.Client.CLI.csproj
+++ b/Breeze.TumbleBit.Client.CLI/Breeze.TumbleBit.Client.CLI.csproj
@@ -7,6 +7,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Breeze.TumbleBit.Client\Breeze.TumbleBit.Client.csproj" />
+    <ProjectReference Include="..\StratisBitcoinFullNode\Stratis.Bitcoin.Api\Stratis.Bitcoin.Api.csproj" />
+    <ProjectReference Include="..\StratisBitcoinFullNode\Stratis.Bitcoin.Features.LightWallet\Stratis.Bitcoin.Features.LightWallet.csproj" />
+    <ProjectReference Include="..\StratisBitcoinFullNode\Stratis.Bitcoin\Stratis.Bitcoin.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Breeze.TumbleBit.Client.CLI/Program.cs
+++ b/Breeze.TumbleBit.Client.CLI/Program.cs
@@ -2,8 +2,13 @@
 using NBitcoin;
 using NTumbleBit.Logging;
 using Stratis.Bitcoin;
+using Stratis.Bitcoin.Api;
 using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.LightWallet;
+using Stratis.Bitcoin.Features.Notifications;
+using Stratis.Bitcoin.Features.WatchOnlyWallet;
+using Stratis.Bitcoin.Utilities;
 
 namespace Breeze.TumbleBit.Client.CLI
 {
@@ -27,6 +32,7 @@ namespace Breeze.TumbleBit.Client.CLI
 			//Start the engines!
 			NodeSettings nodeSettings = NodeSettings.FromArguments(args);
 			FullNode fullNode = StartupFullNode(nodeSettings, tumblerUri);
+            fullNode.Run();
 
 			ITumbleBitManager tumbleBitManager;// = new TumbleBitManager(loggerFactory, );
 
@@ -39,18 +45,17 @@ namespace Breeze.TumbleBit.Client.CLI
 
 	    private static FullNode StartupFullNode(NodeSettings nodeSettings, Uri tumblerUri)
 	    {
-		    //var fullNodeBuilder = new FullNodeBuilder()
-			   // .UseNodeSettings(nodeSettings)
-			   // .UseLightWallet()
-			   // .UseBlockNotification()
-			   // .UseTransactionNotification()
-			   // .UseApi()
-			   // .UseTumbleBit(tumblerUri)
-			   // .UseWatchOnlyWallet()
-			   // .Build();
+            var fullNodeBuilder = new FullNodeBuilder()
+                .UseNodeSettings(nodeSettings)
+                .UseLightWallet()
+                .UseBlockNotification()
+                .UseTransactionNotification()
+                .UseApi()
+                .UseTumbleBit(tumblerUri)
+                .UseWatchOnlyWallet()
+                .Build();
 
-		    //return fullNodeBuilder;
-		    return null;
-	    }
+            return fullNodeBuilder as FullNode;
+        }
     }
 }

--- a/Breeze.TumbleBit.Client/Breeze.TumbleBit.Client.csproj
+++ b/Breeze.TumbleBit.Client/Breeze.TumbleBit.Client.csproj
@@ -28,15 +28,5 @@
     <ProjectReference Include="..\StratisBitcoinFullNode\Stratis.Bitcoin\Stratis.Bitcoin.csproj" />
   </ItemGroup>
 
-  <!-- The problem here is that when a project references both a nuget package and a csproj that lead to the same assembly, the compiler throws an exception.
-       The behavior that's expected is that the project reference wins.
-       Here, having NStratis in both the Stratis.Bitcoin project and in the NTumblebit project leads to an error. 
-       Workaround taken from here https://github.com/dotnet/sdk/issues/364 
-       TODO Remove this once we use nuget packages -->
-  <Target Name="WorkAroundPackageAndProjectReferenceConflict" BeforeTargets="ResolveLockFileReferences">
-    <ItemGroup>
-      <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'%(ResolvedCompileFileDefinitions.Filename)' == 'HashLib'" />
-      <ResolvedCompileFileDefinitions Remove="@(ResolvedCompileFileDefinitions)" Condition="'%(ResolvedCompileFileDefinitions.Filename)' == 'NBitcoin'" />
-    </ItemGroup>
-  </Target>
+ 
 </Project>

--- a/BreezeClient.sln
+++ b/BreezeClient.sln
@@ -11,6 +11,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Bitcoin", "StratisB
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Breeze.TumbleBit.Client.CLI", "Breeze.TumbleBit.Client.CLI\Breeze.TumbleBit.Client.CLI.csproj", "{D5EC2C2A-051B-4C5D-BA37-3A2FA4E02E1A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{9F185BD6-E2D5-4A09-8F4D-041A54489E79}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Bitcoin.Api", "StratisBitcoinFullNode\Stratis.Bitcoin.Api\Stratis.Bitcoin.Api.csproj", "{EDC9CF08-558C-41C8-AC66-356E67B76CA4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Bitcoin.Features.LightWallet", "StratisBitcoinFullNode\Stratis.Bitcoin.Features.LightWallet\Stratis.Bitcoin.Features.LightWallet.csproj", "{4CEA3765-93A8-4B26-A3FA-7C8C06BD70E8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,8 +39,22 @@ Global
 		{D5EC2C2A-051B-4C5D-BA37-3A2FA4E02E1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D5EC2C2A-051B-4C5D-BA37-3A2FA4E02E1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5EC2C2A-051B-4C5D-BA37-3A2FA4E02E1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EDC9CF08-558C-41C8-AC66-356E67B76CA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EDC9CF08-558C-41C8-AC66-356E67B76CA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EDC9CF08-558C-41C8-AC66-356E67B76CA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EDC9CF08-558C-41C8-AC66-356E67B76CA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CEA3765-93A8-4B26-A3FA-7C8C06BD70E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CEA3765-93A8-4B26-A3FA-7C8C06BD70E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CEA3765-93A8-4B26-A3FA-7C8C06BD70E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CEA3765-93A8-4B26-A3FA-7C8C06BD70E8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{160E5F82-4197-433C-84A9-43DE8B3769AC} = {9F185BD6-E2D5-4A09-8F4D-041A54489E79}
+		{389912AE-40DB-483F-A3D0-59A87606E414} = {9F185BD6-E2D5-4A09-8F4D-041A54489E79}
+		{EDC9CF08-558C-41C8-AC66-356E67B76CA4} = {9F185BD6-E2D5-4A09-8F4D-041A54489E79}
+		{4CEA3765-93A8-4B26-A3FA-7C8C06BD70E8} = {9F185BD6-E2D5-4A09-8F4D-041A54489E79}
 	EndGlobalSection
 EndGlobal

--- a/BreezeClient.sln
+++ b/BreezeClient.sln
@@ -9,10 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NTumbleBit", "BreezeCommon\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stratis.Bitcoin", "StratisBitcoinFullNode\Stratis.Bitcoin\Stratis.Bitcoin.csproj", "{389912AE-40DB-483F-A3D0-59A87606E414}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NBitcoin", "StratisBitcoinFullNode\NStratis\NBitcoin\NBitcoin.csproj", "{6CCCE7DF-13D0-40DC-85E4-25E9C0F7D4C5}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HashLib", "StratisBitcoinFullNode\NStratis\Hashing\HashLib\HashLib.csproj", "{BBC6BDA6-F6EF-444B-86CF-5797E53BA20D}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Breeze.TumbleBit.Client.CLI", "Breeze.TumbleBit.Client.CLI\Breeze.TumbleBit.Client.CLI.csproj", "{D5EC2C2A-051B-4C5D-BA37-3A2FA4E02E1A}"
 EndProject
 Global
@@ -33,14 +29,6 @@ Global
 		{389912AE-40DB-483F-A3D0-59A87606E414}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{389912AE-40DB-483F-A3D0-59A87606E414}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{389912AE-40DB-483F-A3D0-59A87606E414}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6CCCE7DF-13D0-40DC-85E4-25E9C0F7D4C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6CCCE7DF-13D0-40DC-85E4-25E9C0F7D4C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6CCCE7DF-13D0-40DC-85E4-25E9C0F7D4C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6CCCE7DF-13D0-40DC-85E4-25E9C0F7D4C5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BBC6BDA6-F6EF-444B-86CF-5797E53BA20D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BBC6BDA6-F6EF-444B-86CF-5797E53BA20D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BBC6BDA6-F6EF-444B-86CF-5797E53BA20D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BBC6BDA6-F6EF-444B-86CF-5797E53BA20D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D5EC2C2A-051B-4C5D-BA37-3A2FA4E02E1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D5EC2C2A-051B-4C5D-BA37-3A2FA4E02E1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D5EC2C2A-051B-4C5D-BA37-3A2FA4E02E1A}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
So in the end I removed the changes I had done in the csproj files and I opted for another solution:
I created a branch of the StratisBitcoinFullNode repo where the Stratis.Bitcoin references Nstratis as a nuget packages.
The BreezeClient uses this branch called nstratis-as-nuget as a submodule.
In order to keep things in sync, we'll need to occasionally update the branch and update the submodule commit reference in the BreezeClient project.

